### PR TITLE
97: changed qpc_tools to qpc-tools in tools install command attributes

### DIFF
--- a/src/community/attributes/attributes-qpc.adoc
+++ b/src/community/attributes/attributes-qpc.adoc
@@ -18,9 +18,9 @@
 :QPCcommandOfflineDownloadToolsPackageStartDownloadRHEL7: https://github.com/quipucords/qpc-tools/releases/latest/download/qpc-tools.el7.noarch.rpm
 :QPCcommandOfflineDownloadToolsPackageNameRHEL6: qpc-tools.el6.noarch.rpm
 :QPCcommandOfflineDownloadToolsPackageStartDownloadRHEL6: https://github.com/quipucords/qpc-tools/releases/latest/download/qpc-tools.el6.noarch.rpm
-:QPCcommandInstallToolsRHEL8: # yum install -y https://github.com/quipucords/qpc-tools/releases/latest/download/qpc_tools.el8.noarch.rpm
-:QPCcommandInstallToolsRHEL7: # yum install -y https://github.com/quipucords/qpc-tools/releases/latest/download/qpc_tools.el7.noarch.rpm
-:QPCcommandInstallToolsRHEL6: # yum install -y https://github.com/quipucords/qpc-tools/releases/latest/download/qpc_tools.el6.noarch.rpm
+:QPCcommandInstallToolsRHEL8: # yum install -y https://github.com/quipucords/qpc-tools/releases/latest/download/qpc-tools.el8.noarch.rpm
+:QPCcommandInstallToolsRHEL7: # yum install -y https://github.com/quipucords/qpc-tools/releases/latest/download/qpc-tools.el7.noarch.rpm
+:QPCcommandInstallToolsRHEL6: # yum install -y https://github.com/quipucords/qpc-tools/releases/latest/download/qpc-tools.el6.noarch.rpm
 
 :QPCcommandOfflineDownloadServerPackageLanding: https://github.com/quipucords/quipucords/releases/latest/
 :QPCcommandOfflineDownloadServerPackageName: quipucords_server_image.tar.gz


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
Changed RHEL 6, 7, 8 attributes that contain the command to install qpc-tools, corrects from qpc_tools to qpc-tools.

Screen cap added to issue that shows change in code.

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Updates #97