### PR TITLE
102: corrected enablement path for discovery installation

### DIFF
--- a/src/community/modules/proc-installing-tools-inst.adoc
+++ b/src/community/modules/proc-installing-tools-inst.adoc
@@ -47,7 +47,7 @@ The procedure at this link includes a step to install {AnsibleName}. Because {Pr
 
 . Enable the {ProductNameShort} repository:
 [source,options="nowrap",subs="attributes"]
-# subscription-manager repos --enable discovery-0-for-rhel8-x86_64-rpms
+# subscription-manager repos --enable discovery-0-for-rhel-8-x86_64-rpms
 
 . Install {ProductToolsName}:
 [source,options="nowrap",subs="attributes"]


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
Fixed enablement path for discovery install in file proc-installing-tools-inst.adoc. Screenshot of doc source included below.

## Example
![image](https://user-images.githubusercontent.com/31351227/73671565-2f7e1280-4679-11ea-92cf-5595bd0bf727.png)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Closes #102
