### PR TITLE
105: add info about same db creds for upgrade, delete mention of cont…

### DIFF
--- a/src/community/modules/proc-installing-scripted-offline-qpc-inst.adoc
+++ b/src/community/modules/proc-installing-scripted-offline-qpc-inst.adoc
@@ -33,6 +33,12 @@ endif::qpc_install_guide[]
 == Installing the server
 
 Install the server. The default server installation process prompts you to supply a password for the {ProductNameShort} server administrator and a password for the {PostgreSQLName} database user.
+[IMPORTANT]
+====
+As a best practice, note the {ProductNameShort} server administrator and the {PostgreSQLName} database user passwords in the password management system that is used by your organization. {ProductNameStartSentence} does not offer a method to recover these passwords.
+
+In addition, if you later use {ProductToolsName} to upgrade {ProductNameShort}, you must use the same database user name and password during the upgrade. The failure to use the same database credentials could result in data loss.
+====
 
 ifdef::discovery_install_guide[]
 . Install the server by entering the following command:

--- a/src/community/modules/proc-installing-scripted-online-inst.adoc
+++ b/src/community/modules/proc-installing-scripted-online-inst.adoc
@@ -26,10 +26,20 @@ To install the {ProductNameShort} server and CLI packages, use the following ste
 
 == Installing the server
 
+
+
+ifdef::discovery_install_guide[]
 Install the server. The default server installation process prompts you to enter your user name and password for the {ContainerCatalogName} (the registry.redhat.io website). It also prompts you to supply a password for the {ProductNameShort} server administrator and a password for the {PostgreSQLName} database user.
+endif::discovery_install_guide[]
+
+ifdef::qpc_install_guide[]
+Install the server. The default server installation process prompts you to supply a password for the {ProductNameShort} server administrator and a password for the {PostgreSQLName} database user. 
+endif::qpc_install_guide[]
 [IMPORTANT]
 ====
 As a best practice, note the {ProductNameShort} server administrator and the {PostgreSQLName} database user passwords in the password management system that is used by your organization. {ProductNameStartSentence} does not offer a method to recover these passwords.
+
+In addition, if you later use {ProductToolsName} to upgrade {ProductNameShort}, you must use the same database user name and password during the upgrade. The failure to use the same database credentials could result in data loss.
 ====
 
 ifdef::discovery_install_guide[]

--- a/src/community/modules/ref-tools-install-options-inst.adoc
+++ b/src/community/modules/ref-tools-install-options-inst.adoc
@@ -35,8 +35,16 @@ ifdef::discovery_install_guide[]
 endif::discovery_install_guide[]
 
 `--db-user=_database_username_`:: Sets the database user name for PostgreSQL. Defaults to `postgres`.
+[IMPORTANT]
+====
+If you later use {ProductToolsName} to upgrade {ProductNameShort}, you must use the same database user name and password during the upgrade. The failure to use the same database credentials could result in data loss.
+====
 
 `--db-password=_database_password_`:: Sets the database user password for PostgreSQL. This option has no default value. If omitted, {ProductToolsName} prompts for a password.
+[IMPORTANT]
+====
+If you later use {ProductToolsName} to upgrade {ProductNameShort}, you must use the same database user name and password during the upgrade. The failure to use the same database credentials could result in data loss.
+====
 
 `--username=_server_username_`:: Sets the {ProductNameShort} server administrator user name. Defaults to `admin`.
 


### PR DESCRIPTION
…ainer catalog in QPC doc

## What's included
Added info about using the same database ID/pw if you use qpc-tools/discovery-tools to upgrade: to the server installation instructions and the server installation options. 
- proc-installing-scripted-offline-qpc-inst.adoc
- proc-installing-scripted-online-inst.adoc
- ref-tools-install-options-inst.adoc

Also fixed a place where the container catalog was mentioned (in error) in the QPC online install info, in the "installing the server" section.

## How to test

Because of the conditional tagging, seeing all the different places affected as source can be a little confusing. @myersCody I will include my local builds in the Slack chat so that you can use these instructions to view the build output:

### open the qpc install guide:
CHECK SERVER INSTRUCTIONS
*this content lives in 2 separate files, so check both (look for the italics to find major sections in the TOC, use back to get back to the TOC)*
- under "Installing Quipucords with the online installation process," click "Installing the server"
- check that container catalog info is NOT mentioned and that the "important" note contains info about using qpc-tools for upgrade
- under "Installing Quipucords with the offline installation process," click "Installing the server"
- check that container catalog info is NOT mentioned and that the "important" note contains info about using qpc-tools for upgrade

CHECK SERVER INSTALLATION OPTIONS
*this is a shared file that appears in both the offline and online sections but you can check both if you want*
- under same major sections, click "Server installation options"
- check that both the `--db-user` and `--db-password` definitions have the new note about using qpc-tools for upgrade 

### open the discovery guide:
CHECK SERVER INSTRUCTIONS
- under the "Installing discovery with the online installation process," click "Installing the server"
- check that container catalog info IS MENTIONED and that the "important" note contains info about using discovery-tools for upgrade

CHECK SERVER INSTALLATION OPTIONS
- click "Server installation options"
- check that both the `--db-user` and `--db-password` definitions have the new note about using discovery-tools for upgrade 


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Closes #105
