### PR TITLE
100: add requirement for EPEL repo for qpc on CentOS 8

### DIFF
--- a/src/community/modules/ref-sw-prerequisites-inst.adoc
+++ b/src/community/modules/ref-sw-prerequisites-inst.adoc
@@ -14,12 +14,15 @@ ifdef::discovery_install_guide[]
 endif::discovery_install_guide[]
 ifdef::qpc_install_guide[]
 ** {RHELName} 6, 7, or 8
-** {CentOSName} 6 or 7
+** {CentOSName} 6, 7, or 8
 +
 [NOTE]
 ====
-{RHELNameShort} 7 or 8 or {CentOSName} 7 are the recommended operating system versions. For {RHELNameShort} 6 or {CentOSName} 6, the minimum required kernel is 2.6.32-431 or later.
+{RHELNameShort} 7 or 8 or {CentOSName} 7 or 8 are the recommended operating system versions. For {RHELNameShort} 6 or {CentOSName} 6, the minimum required kernel is 2.6.32-431 or later.
 ====
+
+* *Additional repositories:* For a {CentOSName} 8 installation, the Extra Packages for Enterprise Linux (EPEL) repository is required to install and use the {ProductToolsName} package. If you are doing an offline installation of {ProductNameShort}, the EPEL repository must be installed on both the connected machine where you download the {ProductNameShort} packages and on the disconnected machine where you install the {ProductNameShort} packages.
+
 endif::qpc_install_guide[]
 
 In addition to these software requirements, {ProductNameShort} has dependencies on other software. However, in some cases these dependencies are installed for you during installation, or instructions for their installation is integrated as part of the {ProductNameShort} installation process. The process to install dependencies can vary according several factors, including your operating system and whether you are doing an offline or online installation. Therefore, install the dependencies only as instructed by the {ProductNameShort} installation steps.


### PR DESCRIPTION
## What's included
Added information about the EPEL requirement for a QPC installation on CentOS 8
- changes are in the ref-sw-prerequisties-inst.adoc file 
This is a shared file for QPC and discovery, so the change is in a conditionalized section for QPC.

## How to test
Will include new qpc and discovery docs in Slack for testing. 

**quipucords install guide**
- In the "Installing prerequisites for Quipucords" section, click "Software prerequisites."
- There's a new bullet for "Additional repositories" as a new prereq with text about the CentOS 8 requirement.
- Also note that the OS version info above that bullet has been changed to include CentOS 8 as a supported OS.

**discovery install guide**
- Do the same steps for the discovery install guide, but notice that there is no new bullet and CentOS 8 information does not appear as a supported OS.

## Updates issue/story
Closes #100